### PR TITLE
Report dollars spent on OpenAI

### DIFF
--- a/agentverse/agents/base.py
+++ b/agentverse/agents/base.py
@@ -48,6 +48,15 @@ class BaseAgent(BaseModel):
         """Add a message to the memory"""
         pass
 
+    def get_spend(self) -> int:
+        return self.llm.get_spend()
+
+    def get_spend_formatted(self) -> int:
+        two_trailing = f"${self.get_spend():.2f}"
+        if two_trailing == "$0.00":
+            return f"${self.get_spend():.6f}"
+        return two_trailing
+
     def get_all_prompts(self, **kwargs):
         prepend_prompt = Template(self.prepend_prompt_template).safe_substitute(
             **kwargs

--- a/agentverse/agents/base.py
+++ b/agentverse/agents/base.py
@@ -48,10 +48,10 @@ class BaseAgent(BaseModel):
         """Add a message to the memory"""
         pass
 
-    def get_spend(self) -> int:
+    def get_spend(self) -> float:
         return self.llm.get_spend()
 
-    def get_spend_formatted(self) -> int:
+    def get_spend_formatted(self) -> str:
         two_trailing = f"${self.get_spend():.2f}"
         if two_trailing == "$0.00":
             return f"${self.get_spend():.6f}"

--- a/agentverse/environments/base.py
+++ b/agentverse/environments/base.py
@@ -46,7 +46,6 @@ class BaseEnvironment(BaseModel):
         """Reset the environment"""
         pass
 
-    @abstractmethod
     def report_metrics(self) -> None:
         """Report useful metrics"""
         pass

--- a/agentverse/environments/base.py
+++ b/agentverse/environments/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from agentverse.logging import logger
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List
@@ -48,6 +49,8 @@ class BaseEnvironment(BaseModel):
 
     def report_metrics(self) -> None:
         """Report useful metrics"""
+        total_spent = sum([agent.get_spend() for agent in self.agents])
+        logger.info(f"Total spent: ${total_spent}")
         pass
 
     def is_done(self) -> bool:

--- a/agentverse/environments/base.py
+++ b/agentverse/environments/base.py
@@ -46,6 +46,11 @@ class BaseEnvironment(BaseModel):
         """Reset the environment"""
         pass
 
+    @abstractmethod
+    def report_metrics(self) -> None:
+        """Report useful metrics"""
+        pass
+
     def is_done(self) -> bool:
         """Check if the environment is done"""
         return self.cnt_turn >= self.max_turns

--- a/agentverse/environments/tasksolving_env/basic.py
+++ b/agentverse/environments/tasksolving_env/basic.py
@@ -108,6 +108,29 @@ class BasicEnvironment(BaseEnvironment):
         self.cnt_turn += 1
         return flatten_result, advice, flatten_plan, logs, self.success
 
+    def iter_agents(self):
+        for role, agent_or_agents in self.agents.items():
+            if isinstance(agent_or_agents, list):
+                for agent in agent_or_agents:
+                    yield role, agent
+            else:
+                yield role, agent_or_agents
+
+    def get_spend(self):
+        total_spent = sum([agent.get_spend() for (_, agent) in self.iter_agents()])
+        return total_spent
+
+    def report_metrics(self) -> None:
+        logger.info("", "Agent spend:", Fore.GREEN)
+        for role, agent in self.iter_agents():
+            name = agent.name.split(":")[0]
+            logger.info(
+                "",
+                f"Agent (Role: {role}) {name}: {agent.get_spend_formatted()}",
+                Fore.GREEN,
+            )
+        logger.info("", f"Total spent: ${self.get_spend():.6f}", Fore.GREEN)
+
     def is_done(self):
         """Check if the environment is done"""
         return self.cnt_turn >= self.max_turn or self.success

--- a/agentverse/llms/base.py
+++ b/agentverse/llms/base.py
@@ -22,6 +22,13 @@ class BaseLLM(BaseModel):
     max_retry: int = Field(default=3)
 
     @abstractmethod
+    def get_spend(self) -> float:
+        """
+        Number of USD spent
+        """
+        return -1.0
+
+    @abstractmethod
     def generate_response(self, **kwargs) -> LLMResult:
         pass
 

--- a/agentverse/simulation.py
+++ b/agentverse/simulation.py
@@ -43,6 +43,7 @@ class Simulation:
         self.environment.reset()
         while not self.environment.is_done():
             asyncio.run(self.environment.step())
+        self.environment.report_metrics()
 
     def reset(self):
         self.environment.reset()

--- a/agentverse/tasksolving.py
+++ b/agentverse/tasksolving.py
@@ -67,7 +67,8 @@ class TaskSolving:
                 self.environment.step(advice, previous_plan)
             )
             self.logs += logs
-        self.save_result(previous_plan, result)
+        self.environment.report_metrics()
+        self.save_result(previous_plan, result, self.environment.get_spend())
         return previous_plan, result, self.logs
 
     def singleagent_thinking(self, preliminary_solution, advice) -> str:
@@ -80,10 +81,11 @@ class TaskSolving:
     def reset(self):
         self.environment.reset()
 
-    def save_result(self, plan: str, result: str):
+    def save_result(self, plan: str, result: str, spend: float):
         """Save the result to the result file"""
-        result_file_path = "../results/" + self.task + ".txt"
+        result_file_path = "./results/" + self.task + ".txt"
         os.makedirs(os.path.dirname(result_file_path), exist_ok=True)
         with open(result_file_path, "w") as f:
             f.write("[Final Plan]\n" + plan + "\n\n")
             f.write("[Result]\n" + result)
+            f.write(f"[Spent]\n${spend}")


### PR DESCRIPTION
The user does not have visibility into the cost of each session. This PR adds a `report_metrics` callback for environments to display useful metrics to the user.

This has been implemented for the TaskSolving environment. Try "brainstorming" to see the result.

```
$ python main_tasksolving_cli.py --task tasksolving/brainstorming
...
Agent spend:  
Agent (Role: AGENT_TYPES.ROLE_ASSIGNMENT) role assigner: $0.001631  
Agent (Role: AGENT_TYPES.SOLVER) A mechanical engineer specialized in hydrogen storage technologies: $0.01  
Agent (Role: AGENT_TYPES.CRITIC) An electrical engineer with expertise in renewable energy integration: $0.002690  
Agent (Role: AGENT_TYPES.CRITIC) A regulatory specialist familiar with hydrogen storage regulations: $0.002037  
Agent (Role: AGENT_TYPES.CRITIC) An infrastructure planner with experience in large-scale projects: $0.002518  
Agent (Role: AGENT_TYPES.EXECUTION) Dummy Executor: $0.000000  
Agent (Role: AGENT_TYPES.EVALUATION) Evaluator: $0.003592  
Total spent: $0.018993 
```