### PR TITLE
add simulation ui params

### DIFF
--- a/agentverse/gui.py
+++ b/agentverse/gui.py
@@ -30,13 +30,14 @@ class GUI:
     the UI of frontend
     """
 
-    def __init__(self, task: str, tasks_dir: str):
+    def __init__(self, task: str, tasks_dir: str,ui_kwargs: Dict[str, str]):
         """
         init a UI.
         default number of students is 0
         """
         self.messages = []
         self.task = task
+        self.ui_kwargs = ui_kwargs
         if task == "pipeline_brainstorming":
             self.backend = TaskSolving.from_task(task, tasks_dir)
         else:
@@ -502,5 +503,5 @@ class GUI:
                     show_progress=False,
                 )
 
-        demo.queue(concurrency_count=5, max_size=20).launch()
+        demo.queue(concurrency_count=5, max_size=20).launch(**self.ui_kwargs)
         # demo.launch()

--- a/agentverse_command/main_simulation_gui.py
+++ b/agentverse_command/main_simulation_gui.py
@@ -2,17 +2,6 @@ import os
 from agentverse.gui import GUI
 from argparse import ArgumentParser
 
-def is_share(v):
-    if isinstance(v, bool):
-        return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
-        return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        import argparse
-        raise argparse.ArgumentTypeError('Boolean value expected.')
-
 parser = ArgumentParser()
 parser.add_argument("--task", type=str, default="simulation/nlp_classroom_9players")
 parser.add_argument(
@@ -21,18 +10,19 @@ parser.add_argument(
     default=os.path.join(os.path.dirname(__file__), "..", "agentverse", "tasks"),
 )
 parser.add_argument("--share",
-                        type=is_share,
-                        default=False,
-                        help="Create a publicly shareable link")
-parser.add_argument("--server_name",type=str,default="127.0.0.1",help="Server name")
+                    action='store_true', 
+                    default=False,
+                    help="Create a publicly shareable link")
+parser.add_argument("--server_name",
+                    type=str,
+                    default="127.0.0.1",
+                    help="Server name")
 
 args = parser.parse_args()
-
 
 def cli_main():
     ui = GUI(args.task, args.tasks_dir,ui_kwargs={"share":args.share,"server_name":args.server_name})
     ui.launch()
-
 
 if __name__ == "__main__":
     cli_main()

--- a/agentverse_command/main_simulation_gui.py
+++ b/agentverse_command/main_simulation_gui.py
@@ -2,6 +2,17 @@ import os
 from agentverse.gui import GUI
 from argparse import ArgumentParser
 
+def is_share(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        import argparse
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
 parser = ArgumentParser()
 parser.add_argument("--task", type=str, default="simulation/nlp_classroom_9players")
 parser.add_argument(
@@ -9,11 +20,17 @@ parser.add_argument(
     type=str,
     default=os.path.join(os.path.dirname(__file__), "..", "agentverse", "tasks"),
 )
+parser.add_argument("--share",
+                        type=is_share,
+                        default=False,
+                        help="Create a publicly shareable link")
+parser.add_argument("--server_name",type=str,default="127.0.0.1",help="Server name")
+
 args = parser.parse_args()
 
 
 def cli_main():
-    ui = GUI(args.task, args.tasks_dir)
+    ui = GUI(args.task, args.tasks_dir,ui_kwargs={"share":args.share,"server_name":args.server_name})
     ui.launch()
 
 


### PR DESCRIPTION
issue #61
 
Now we add parameters in simulation_ui:
- server_name: Default server name is "127.0.0", now you can change server name, such as "0.0.0.0".
- share:  If want create a publicly shareable link, you can set value as true, yes, y or 1 

for example
```
python3 agentverse_command/main_simulation_gui.py --task simulation/sde_team/sde_team_3players --share true --server_name 0.0.0.0
```

