### PR TITLE
feat: allow custom openai base url

### DIFF
--- a/agentverse/llms/openai.py
+++ b/agentverse/llms/openai.py
@@ -30,6 +30,10 @@ else:
     if os.environ.get("OPENAI_API_KEY") != None:
         openai.api_key = os.environ.get("OPENAI_API_KEY")
         is_openai_available = True
+        # set openai api base url if it is set
+        if os.environ.get("OPENAI_BASE_URL") != None:
+            openai.base_url = os.environ.get("OPENAI_BASE_URL")
+            print("use new openai base url", openai.base_url)
     elif os.environ.get("AZURE_OPENAI_API_KEY") != None:
         openai.api_type = "azure"
         openai.api_key = os.environ.get("AZURE_OPENAI_API_KEY")


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->


### 🤔 What is the nature of this change? 

- [x] New feature 

### 🔗 Related Issue 

- https://github.com/OpenBMB/AgentVerse/issues/110


### 💡 Background or solution 

If the user has a proxy service of the OpenAI API, or a Model API that is compatible with it, it should also be allowed to call it directly by setting environment variables without setting the locally running model.

Simpler and easier to use.

### 📝 Changelog 

Just add an environment variable, when the OpenAI Client is initialized
